### PR TITLE
Remove isStrict check and ignore non-numeric keys of arrays

### DIFF
--- a/src/amf0.js
+++ b/src/amf0.js
@@ -44,9 +44,7 @@ class AMF0 extends AMF {
     return new types.AMFNull(AMF0.NULL)
   }
   handleArray(value) {
-    return types.AMFArray.isStrict(value)
-      ? new types.AMFArray(AMF0.ARRAY_STRICT, value, { propertyEncoder: this })
-      : new types.AMFObject(AMF0.ARRAY_ECMA, value, { propertyEncoder: this })
+    return new types.AMFArray(AMF0.ARRAY_STRICT, value, { propertyEncoder: this })
   }
   handleObject(value) {
     return new types.AMFObject(AMF0.OBJECT, value, { propertyEncoder: this, propertyDecoder: this, endType: AMF0.OBJECT_END })

--- a/src/amf_types/array.js
+++ b/src/amf_types/array.js
@@ -13,14 +13,10 @@ class AMFArray extends AMFType {
   }
   encode() {
     const value = Buffer.concat([
-      this.encodeLength(), 
-      this.propertyEncoder.encode(this.value)
+      this.encodeLength(),
+      this.propertyEncoder.encode(...this.value)
     ])
     return super.encode(value)
-  }
-  static isStrict(array) {
-    const keys = Object.keys(array)
-    return keys.reduce((isStrict, key) => isStrict && Number.isInteger(key), true)
   }
 }
 


### PR DESCRIPTION
isStrict was completely broken, so this PR will ignore non-numeric keys of arrays.
Also, the array value should be spread to AMF.encode as it expect ...args instead of a single array arg.